### PR TITLE
tell picosvg to clip to viewbox, fixes a couple flags scaled incorrectly

### DIFF
--- a/naive_warp.py
+++ b/naive_warp.py
@@ -535,7 +535,7 @@ def normalize_flag_aspect(svg, width, height):
 
 
 def main(argv):
-    svg = load_svg(argv).topicosvg()
+    svg = load_svg(argv).topicosvg().clip_to_viewbox(inplace=True)
 
     normalize_flag_aspect(svg, FLAGS.width, FLAGS.height)
 


### PR DESCRIPTION
some flags have paths that exceed the viewbox, when we map them to the warp mesh we use the bbox thus they get warped incorrectly: e.g. TZ.svg
If we clip them to their viewbox (as they will be when rendered), we get the correct warp, see screenshot:

before:
<img width="300" alt="Screenshot 2021-03-16 at 12 20 32" src="https://user-images.githubusercontent.com/6939968/111308294-67180600-8652-11eb-8192-fd322d60c7df.png">

after:
<img width="300" alt="Screenshot 2021-03-16 at 12 21 00" src="https://user-images.githubusercontent.com/6939968/111308299-68493300-8652-11eb-9efc-1685185fefa4.png">