### PR TITLE
use bezierTools approximate methods for computing arc-length

### DIFF
--- a/naive_warp.py
+++ b/naive_warp.py
@@ -20,8 +20,8 @@ from absl import flags
 from cu2qu import curve_to_quadratic as cubic_to_quad
 import enum
 from fontTools.misc.bezierTools import (
-    calcCubicArcLength,
-    calcQuadraticArcLength,
+    approximateCubicArcLength,
+    approximateQuadraticArcLength,
     splitCubic,
     splitCubicAtT,
     splitQuadraticAtT,
@@ -294,9 +294,9 @@ def _ref_pts(view_box, curve):
     # we award you one segment per 1000th of viewbox diagonal
     # 100th didn't seem to be enough
     if len(curve) == 4:
-        curve_len = calcCubicArcLength(*curve)
+        curve_len = approximateCubicArcLength(*curve)
     elif len(curve) == 3:
-        curve_len = calcQuadraticArcLength(*curve)
+        curve_len = approximateQuadraticArcLength(*curve)
     else:
         raise AssertionError(len(curve))
     diagonal = _dist((0, 0), (view_box.w, view_box.h))


### PR DESCRIPTION
these seem to be more stable than the calc- equivalents, sometimes the latter fall into RecursionError trap.
We don't need to be super precise, and these are good enough (also purportedly faster).

For reference, see https://github.com/fonttools/fonttools/blob/main/Lib/fontTools/misc/bezierTools.py

In particular, this PR fixes warping the IO.svg flag

Hey, look at those sexy waves of waves

<img width="1724" alt="Untitled" src="https://user-images.githubusercontent.com/6939968/111335274-29c07200-866c-11eb-8eed-87c010451aa5.png">
