### PR TITLE
flags_preflight: fix regex matching .X floats with omitted leading 0s

### DIFF
--- a/flag_preflight.py
+++ b/flag_preflight.py
@@ -25,7 +25,9 @@ flags.DEFINE_string("out_file", "-", "Output, - means stdout")
 
 
 def _fix_pt(name, attrib):
-    while match := re.search(r"([0-9]+(?:[.][0-9]*)?)\s*pt", attrib[name]):
+    while match := re.search(
+        r"(?:((?:[0-9]+(?:\.[0-9]*)?)|(?:\.[0-9]+)))\s*pt", attrib[name]
+    ):
         value = attrib[name]
         new_sz = ntos(round(float(match.group(1)) * 1.25, 2))
         new_value = value[: match.start()] + new_sz + value[match.end() :]


### PR DESCRIPTION
The GS.svg flag contains a stroke-width=.99323pt float without the leading 0, which our flags_preflight.py's _fix_pt function turns into an invalid float with two periods. This PR fixes the regex pattern to also match float strings with omitted leading 0.