### PR TITLE
flags_preflight: strip default 'display:inline' and unused 'font-size' from style attrs

### DIFF
--- a/flag_preflight.py
+++ b/flag_preflight.py
@@ -51,6 +51,13 @@ def main(argv):
                 el.attrib[new_name] = el.attrib[name]
                 del el.attrib[name]
 
+            # picosvg doesn't support the 'display' attribute, and there's one flag
+            # AC.svg (Ascension Island) which uses a style="display:inline" but that
+            # is redundant since 'inline' is already the default value for that that
+            # property and thus can be safely omitted.
+            if name == "style" and "display:inline" in el.attrib[name]:
+                el.attrib[name] = el.attrib[name].replace("display:inline", "")
+
     write_xml(FLAGS.out_file, tree, pretty=False)
 
 


### PR DESCRIPTION
The Ascension Island's flag (AC.svg) uses a `style="display:inline"` but that is already the default value for 'display' property.

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/display

picosvg chokes on that unsupported attribute while un-grouping. It's only this one flag.. After this we are down to 6 flags that fail wave_ninja.py, I'm trying to fix them one by one.