### PR TITLE
close open sub-paths to make sure we warp implied self-closing line

### DIFF
--- a/naive_warp.py
+++ b/naive_warp.py
@@ -183,6 +183,17 @@ class FlagWarp:
         return _cubic_deriv_pos(1, *self._seg_ending_at(pt[0]))
 
 
+def close_open_subpaths(path):
+    def callback(subpath_start, curr_xy, cmd, args, prev_xy, prev_cmd, prev_args):
+        if cmd.upper() == "M" and prev_cmd is not None and prev_cmd.upper() != "Z":
+            return (("Z", ()), (cmd, args))
+        return ((cmd, args),)
+
+    path.walk(callback)
+    if not path.d.endswith(("Z", "z")):
+        path.end()
+
+
 def _cubic_callback(subpath_start, curr_xy, cmd, args, prev_xy, prev_cmd, prev_args):
     if cmd.upper() == "M":
         return ((cmd, args),)
@@ -561,6 +572,7 @@ def main(argv):
         shape.explicit_lines(inplace=True)
         shape.arcs_to_cubics(inplace=True)
         shape.expand_shorthand(inplace=True)
+        close_open_subpaths(shape)
         shape.walk(prep_callback)
         shape.walk(path_warp.warp_callback)
         shape.round_floats(2, inplace=True)


### PR DESCRIPTION
There are a couple of flags (e.g. AS.svg) that contain a triangle composed of a move and two lines, without the closing 'Z'.

```xml
<path fill="#FFFFFF" d="M107.14,250L1000,26.79v446.42"/
```

For this reason the last implied line is not warped. Since we run topicosvg() all strokes have been converted to filled paths, so it is safe to assume all the paths are going to be filled only, and as such they will be rendered _as if_ they had a Z at the end. We add that Z here, so in the prep_callback we can turn that into a line, which is then warped as usual.

The AS.svg flag before this PR:

<img width="400" alt="Screenshot 2021-04-08 at 13 10 33" src="https://user-images.githubusercontent.com/6939968/114024493-07390780-986c-11eb-875a-0d240c8e6f40.png">


And after this PR:

<img width="400" alt="Screenshot 2021-04-08 at 13 11 17" src="https://user-images.githubusercontent.com/6939968/114024505-0bfdbb80-986c-11eb-9c18-42b29cb87606.png">
