### PR TITLE
change default precision to 1/1000th of viewbox diagonal

### DIFF
--- a/naive_warp.py
+++ b/naive_warp.py
@@ -40,7 +40,7 @@ from picosvg.svg_transform import Affine2D
 from picosvg.svg import _GRADIENT_CLASSES, SVGLinearGradient, SVGRadialGradient
 
 
-DEFAULT_PRECISION = 200
+DEFAULT_PRECISION = 1000
 DEFAULT_FLATNESS = 1.0001
 # The noto-emoji flags default width/height aspect ratio is 5/3 (see waveflag.c)
 DEFAULT_WIDTH = 1000
@@ -57,7 +57,7 @@ flags.DEFINE_enum(
     "How to generate final curves.",
 )
 flags.DEFINE_float(
-    "precision", DEFAULT_PRECISION, "Default: 1/200th of the viewbox diagonal"
+    "precision", DEFAULT_PRECISION, "Default: 1/1000th of the viewbox diagonal"
 )
 flags.DEFINE_float(
     "flatness",


### PR DESCRIPTION
this improves the warping of very long segments that span across the wave such as the flags' rectangles.
It doesn't increase the file size overall, since our initial parametrization is good enough that we very rarely end up exceeding the precision threshold

E.g. see this detail from the serbian flag, notice that the crown sits exactly at the limit between the red and blue horizontal stripes:

<img width="300" alt="Screenshot 2021-05-13 at 16 46 37" src="https://user-images.githubusercontent.com/6939968/118151027-1848db80-b40b-11eb-9866-f27086891b11.png">

After warping with the old default precision (1/200th of diagonal), the position of the emblem looks slightly off (notice the blue strip)

<img width="300" alt="Screenshot 2021-05-13 at 16 38 55" src="https://user-images.githubusercontent.com/6939968/118151148-39113100-b40b-11eb-80c2-2e153f7cfed0.png">

With --precision=1000 it looks better and the emblem is perfectly aligned:

<img width="300" alt="Screenshot 2021-05-13 at 16 46 09" src="https://user-images.githubusercontent.com/6939968/118151284-5e05a400-b40b-11eb-8080-074b6bfd8269.png">

