### PR TITLE
Add border to SVG flags 

### DIFF
--- a/warp_runner.py
+++ b/warp_runner.py
@@ -12,11 +12,15 @@ flags.DEFINE_string("out_file", "-", "Output, - means stdout")
 flags.DEFINE_string(
     "err_file", "-", "Where to write output for failures, - means stderr"
 )
+flags.DEFINE_bool("border", True, "Whether to add a border to the flag")
 
 
 def main(argv):
     assert len(argv) == 2
-    cmd = ("python", "../naive_warp.py", "--out_file", FLAGS.out_file, argv[1])
+    cmd = ["python", "../naive_warp.py", "--out_file", FLAGS.out_file]
+    if not FLAGS.border:
+        cmd.extend(["--border_size", 0])
+    cmd.append(argv[1])
     cmd_result = subprocess.run(cmd, capture_output=True, text=True)
     if cmd_result.returncode != 0:
         result = [

--- a/wave_list.txt
+++ b/wave_list.txt
@@ -1,3 +1,4 @@
+# input-filename | output-name | border-size(optional)
 third_party/region-flags/svg/PY.svg emoji_u1f1f5_1f1fe.svg
 third_party/region-flags/svg/HU.svg emoji_u1f1ed_1f1fa.svg
 third_party/region-flags/svg/TH.svg emoji_u1f1f9_1f1ed.svg
@@ -104,7 +105,7 @@ third_party/region-flags/svg/CM.svg emoji_u1f1e8_1f1f2.svg
 third_party/region-flags/svg/ZA.svg emoji_u1f1ff_1f1e6.svg
 third_party/region-flags/svg/VC.svg emoji_u1f1fb_1f1e8.svg
 third_party/region-flags/svg/GA.svg emoji_u1f1ec_1f1e6.svg
-third_party/region-flags/svg/MQ.svg emoji_u1f1f2_1f1f6.svg
+third_party/region-flags/svg/MQ.svg emoji_u1f1f2_1f1f6.svg 0
 third_party/region-flags/svg/BG.svg emoji_u1f1e7_1f1ec.svg
 third_party/region-flags/svg/FM.svg emoji_u1f1eb_1f1f2.svg
 third_party/region-flags/svg/AS.svg emoji_u1f1e6_1f1f8.svg
@@ -140,7 +141,7 @@ third_party/region-flags/svg/GW.svg emoji_u1f1ec_1f1fc.svg
 third_party/region-flags/svg/CY.svg emoji_u1f1e8_1f1fe.svg
 third_party/region-flags/svg/ZM.svg emoji_u1f1ff_1f1f2.svg
 third_party/region-flags/svg/JE.svg emoji_u1f1ef_1f1ea.svg
-third_party/region-flags/svg/NP.svg emoji_u1f1f3_1f1f5.svg
+third_party/region-flags/svg/NP.svg emoji_u1f1f3_1f1f5.svg 0
 third_party/region-flags/svg/GM.svg emoji_u1f1ec_1f1f2.svg
 third_party/region-flags/svg/BS.svg emoji_u1f1e7_1f1f8.svg
 third_party/region-flags/svg/GB-ENG.svg emoji_u1f3f4_e0067_e0062_e0065_e006e_e0067_e007f.svg
@@ -222,7 +223,7 @@ third_party/region-flags/svg/AO.svg emoji_u1f1e6_1f1f4.svg
 third_party/region-flags/svg/DZ.svg emoji_u1f1e9_1f1ff.svg
 third_party/region-flags/svg/TF.svg emoji_u1f1f9_1f1eb.svg
 third_party/region-flags/svg/LB.svg emoji_u1f1f1_1f1e7.svg
-third_party/region-flags/svg/PM.svg emoji_u1f1f5_1f1f2.svg
+third_party/region-flags/svg/PM.svg emoji_u1f1f5_1f1f2.svg 0
 third_party/region-flags/svg/CO.svg emoji_u1f1e8_1f1f4.svg
 third_party/region-flags/svg/VE.svg emoji_u1f1fb_1f1ea.svg
 third_party/region-flags/svg/WF.svg emoji_u1f1fc_1f1eb.svg
@@ -232,7 +233,7 @@ third_party/region-flags/svg/GP.svg emoji_u1f1ec_1f1f5.svg
 third_party/region-flags/svg/CR.svg emoji_u1f1e8_1f1f7.svg
 third_party/region-flags/svg/SC.svg emoji_u1f1f8_1f1e8.svg
 third_party/region-flags/svg/NI.svg emoji_u1f1f3_1f1ee.svg
-third_party/region-flags/svg/GF.svg emoji_u1f1ec_1f1eb.svg
+third_party/region-flags/svg/GF.svg emoji_u1f1ec_1f1eb.svg 0
 third_party/region-flags/svg/RO.svg emoji_u1f1f7_1f1f4.svg
 third_party/region-flags/svg/UZ.svg emoji_u1f1fa_1f1ff.svg
 third_party/region-flags/svg/MV.svg emoji_u1f1f2_1f1fb.svg

--- a/wave_ninja.py
+++ b/wave_ninja.py
@@ -63,11 +63,21 @@ def main(_) -> None:
             util_path = rel_build(Path("naive_warp.py"))
             nw.rule(f"waveflag", f"python {util_path} --out_file $out $in")
             nw.newline()
+            nw.rule(
+                f"waveflag-no-border",
+                f"python {util_path} --border_size 0 --out_file $out $in",
+            )
+            nw.newline()
         else:
             util_path = rel_build(Path("warp_runner.py"))
             nw.rule(
                 f"waveflag",
                 f"python {util_path} --err_file {err_file} --out_file $out $in",
+            )
+            nw.newline()
+            nw.rule(
+                f"waveflag-no-border",
+                f"python {util_path} --noborder --err_file {err_file} --out_file $out $in",
             )
             nw.newline()
 
@@ -77,7 +87,13 @@ def main(_) -> None:
 
         with open("wave_list.txt") as f:
             for line in f:
-                src_svg, wave_name = (p.strip() for p in line.split(" "))
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                src_svg, wave_name, *options = (p.strip() for p in line.split(" "))
+                waveflag_rule = "waveflag"
+                if options and not bool(int(options[0])):
+                    waveflag_rule = "waveflag-no-border"
 
                 nw.build(
                     str(preflight_out_dir() / src_svg),
@@ -87,7 +103,7 @@ def main(_) -> None:
 
                 nw.build(
                     str(waved_out_dir() / wave_name),
-                    "waveflag",
+                    waveflag_rule,
                     str(preflight_out_dir() / src_svg),
                 )
 


### PR DESCRIPTION
Partly fixes #20

It turns out we don't actually need MULTIPLY compositing mode to stick a border around flags, normal alpha blending achieves the same visual effect (I suspect because the border is gray?). So we can add the border directly to the waved SVG flags (the soft-light we'll have to add it directly to the built COLRv1 table as post-processing step for SVG can't do soft-light -- or rather one could use CSS mix-blend-mode but it won't work for OT-SVG anyway so it's a dead end).

Note this PR branch si based off #22, so to avoid conflicts it's better to merge the latter first.